### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/gitjoasimonson/c628e767-f76a-41bc-8a7a-25ab051c5730/a03e55ba-45d9-47a7-8145-af66c265c597/_apis/work/boardbadge/8c6ef803-c79c-4279-9108-138c05963fb1)](https://dev.azure.com/gitjoasimonson/c628e767-f76a-41bc-8a7a-25ab051c5730/_boards/board/t/a03e55ba-45d9-47a7-8145-af66c265c597/Microsoft.RequirementCategory)
 # :pushpin: Copa do Mundo de Filmes
 * [O que é o projeto](#about)
 * [Como usar](#run)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/gitjoasimonson/c628e767-f76a-41bc-8a7a-25ab051c5730/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.